### PR TITLE
fix a labelling bug for filedataset types of data and readme fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For requirements please see: _[requirements.txt](requirements.txt)_.
 Active learning is a special case of machine learning in which a learning
 algorithm is able to interactively query the user (or some other information
 source) to obtain the desired outputs at new data points
-([Wiki](https://en.wikipedia.org/wiki/Active_learning)).
+(to understand the concept in more depth, refer to our [tutorial](https://baal.readthedocs.io/en/latest/)).
 
 The goal of baal team is to make a production level ready framework for
 active-learning. In this repo, you could find a set of heuristics that we
@@ -112,8 +112,8 @@ based on the calculated uncertainty of the pool.
 ### Re-run our Experiments
 
 ```bash
-docker build [--target prod_baal] -t baal .
-docker run --rm baal python3 experiments/vgg_mcdropout_cifar10.py 
+nvidia-docker build [--target prod_baal] -t baal .
+nvidia-docker run --rm baal python3 experiments/vgg_mcdropout_cifar10.py 
 ```
 
 ### Use BaaL for YOUR Experiments
@@ -128,7 +128,7 @@ Simply build the dockerfile as below:
 
 ```bash
 git clone git@github.com:ElementAI/baal.git
-docker build [--target base_baal] -t baal-dev .
+nvidia-docker build [--target base_baal] -t baal-dev .
 ```
 
 Now you have all the requirements to start contributing to BaaL. _**YEAH!**_

--- a/src/baal/active/dataset.py
+++ b/src/baal/active/dataset.py
@@ -1,4 +1,5 @@
 from copy import copy
+import warnings
 from itertools import zip_longest
 from typing import Union, Optional, Callable, Tuple, List, Any
 
@@ -134,7 +135,13 @@ class ActiveLearningDataset(torchdata.Dataset):
         for index, val in zip_longest(indexes, value, fillvalue=None):
             if self.can_label and val is not None:
                 self._dataset.label(index, val)
-            self._labelled[index] = 1
+                self._labelled[index] = 1
+            elif not self.can_label:
+                self._labelled[index] = 1
+                if val is not None:
+                    warnings.warn(
+                        "We will consider the original label of this datasample : {}.".format(
+                            self._dataset[index][0], self._dataset[index][1]), UserWarning)
 
     def label_randomly(self, n: int = 1) -> None:
         """

--- a/tests/active/dataset_test.py
+++ b/tests/active/dataset_test.py
@@ -54,10 +54,17 @@ class ActiveDatasetTest(unittest.TestCase):
 
     def test_pool(self):
         self.dataset._dataset.label = unittest.mock.MagicMock()
+        labels_initial = self.dataset.n_labelled
         self.dataset.can_label = False
-        self.dataset.label(0)
+        self.dataset.label(0, value=np.arange(1, 10))
         self.dataset._dataset.label.assert_not_called()
+        labels_next_1 = self.dataset.n_labelled
+        assert labels_next_1 == labels_initial + 1
         self.dataset.can_label = True
+        self.dataset.label(np.arange(0, 9))
+        self.dataset._dataset.label.assert_not_called()
+        labels_next_2 = self.dataset.n_labelled
+        assert labels_next_1 == labels_next_2
         self.dataset.label(np.arange(0, 9), value=np.arange(1, 10))
         assert self.dataset._dataset.label.called_once_with(np.arange(1, 10))
         # cleanup
@@ -65,8 +72,8 @@ class ActiveDatasetTest(unittest.TestCase):
         self.dataset.can_label = False
 
         pool = self.dataset.pool
-        assert np.equal([i for i in pool], [(i, -1) for i in np.arange(10, 100)]).all()
-        assert np.equal([i for i in self.dataset], [(i, i) for i in np.arange(10)]).all()
+        assert np.equal([i for i in pool], [(i, -1) for i in np.arange(2, 100)]).all()
+        assert np.equal([i for i in self.dataset], [(i, i) for i in np.arange(2)]).all()
 
     def test_get_raw(self):
         # check that get_raw returns the same thing regardless of labelling


### PR DESCRIPTION
## Summary:
Readme changed `docker` to `nvidia-docker`
fix in `ActiveLearningDataset.label` . Before if the `FileDataset` type had `value=None` still that data point was marked as labelled in `self._labelled`
### Features:


## Checklist:

* [x ] Your code is documented (To validate this, add your module to `tests/documentation_test.py`).
* [x ] Your code is tested with unit tests.
* [x] You moved your Issue to the PR state.
