### PR TITLE
Add Early Stopping to fit_and_test

### DIFF
--- a/src/baal/modelwrapper.py
+++ b/src/baal/modelwrapper.py
@@ -149,7 +149,8 @@ class ModelWrapper:
                                    workers: int = 4,
                                    collate_fn: Optional[Callable] = None,
                                    return_best_weights=False,
-                                   patience=None):
+                                   patience=None,
+                                   min_epoch_for_es=0):
         """
         Train and test the model on both Dataset `train_dataset`, `test_dataset`.
 
@@ -165,6 +166,7 @@ class ModelWrapper:
             return_best_weights (bool): If True, will keep the best weights and return them.
             patience (Optional[int]): If provided, will use early stopping to stop after
                                         `patience` epoch without improvement.
+            min_epoch_for_es (int): Epoch at which the early stopping starts.
 
         Returns:
             History and best weights if required.
@@ -184,7 +186,7 @@ class ModelWrapper:
                 if return_best_weights:
                     best_weight = deepcopy(self.state_dict())
 
-            if patience is not None and (e - best_epoch) > patience:
+            if patience is not None and (e - best_epoch) > patience and (e > min_epoch_for_es):
                 # Early stopping
                 break
 

--- a/tests/modelwrapper_test.py
+++ b/tests/modelwrapper_test.py
@@ -294,8 +294,20 @@ class ModelWrapperTest(unittest.TestCase):
         res = self.wrapper.train_and_test_on_datasets(self.dataset, self.dataset,
                                                       self.optim, 32, 50,
                                                       False, return_best_weights=True, patience=1)
+
         assert len(res) == 2
-        assert len(res[0]) != 50
+        assert len(res[0]) < 50
+
+        mock = Mock()
+        mock.side_effect = (((np.linspace(0, 50) - 10) / 10) ** 2).tolist()
+        self.wrapper.test_on_dataset = mock
+        res = self.wrapper.train_and_test_on_datasets(self.dataset, self.dataset,
+                                                      self.optim, 32, 50,
+                                                      False, return_best_weights=True, patience=1,
+                                                      min_epoch_for_es=20)
+        assert len(res) == 2
+        assert len(res[0]) < 50 and len(res[0]) > 20
+
 
 
 if __name__ == '__main__':

--- a/tests/modelwrapper_test.py
+++ b/tests/modelwrapper_test.py
@@ -290,7 +290,7 @@ class ModelWrapperTest(unittest.TestCase):
         assert isinstance(res[1], dict)
         mock = Mock()
         mock.side_effect = (((np.linspace(0, 50) - 10) / 10) ** 2).tolist()
-        self.wrapper.train_on_dataset = mock
+        self.wrapper.test_on_dataset = mock
         res = self.wrapper.train_and_test_on_datasets(self.dataset, self.dataset,
                                                       self.optim, 32, 50,
                                                       False, return_best_weights=True, patience=1)

--- a/tests/modelwrapper_test.py
+++ b/tests/modelwrapper_test.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import Mock
 
 import numpy as np
 import pytest
@@ -278,6 +279,7 @@ class ModelWrapperTest(unittest.TestCase):
         assert (self.wrapper.metrics['test_cls_report'].value['accuracy'] != 0).any()
 
     def test_train_and_test(self):
+
         res = self.wrapper.train_and_test_on_datasets(self.dataset, self.dataset, self.optim, 32, 5,
                                                       False, return_best_weights=False)
         assert len(res) == 5
@@ -286,6 +288,14 @@ class ModelWrapperTest(unittest.TestCase):
         assert len(res) == 2
         assert len(res[0]) == 5
         assert isinstance(res[1], dict)
+        mock = Mock()
+        mock.side_effect = (((np.linspace(0, 50) - 10) / 10) ** 2).tolist()
+        self.wrapper.train_on_dataset = mock
+        res = self.wrapper.train_and_test_on_datasets(self.dataset, self.dataset,
+                                                      self.optim, 32, 50,
+                                                      False, return_best_weights=True, patience=1)
+        assert len(res) == 2
+        assert len(res[0]) != 50
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary:
Add Early Stopping to fit_and_test
### Features:
* Able to specify the patience before quitting.

## Checklist:

* [x] Your code is documented (To validate this, add your module to `tests/documentation_test.py`).
* [x] Your code is tested with unit tests.
* [ ] You moved your Issue to the PR state.
