### PR TITLE
Add ConsistentDropout 

### DIFF
--- a/src/baal/bayesian/__init__.py
+++ b/src/baal/bayesian/__init__.py
@@ -1,2 +1,3 @@
 from .dropout import Dropout
+from .consistent_dropout import ConsistentDropout
 from .weight_drop import MCDropoutConnectModule

--- a/src/baal/bayesian/consistent_dropout.py
+++ b/src/baal/bayesian/consistent_dropout.py
@@ -13,20 +13,20 @@ class ConsistentDropout(_DropoutNd):
 
     This is slower than using regular Dropout, but it is useful
     when you want to use the same set of weights for each sample used in inference.
-    
+
     From BatchBALD (Kirsch et al, 2019), this is necessary to use BatchBALD and remove noise 
     from the prediction.
 
     Args:
         p (float): probability of an element to be zeroed. Default: 0.5
-	
-	Notes:
-		For optimal results, you should use a batch size of one
-		during inference time.
-		Furthermore, to guarantee that each sample uses the same
-		set of weights,
-		you must use `replicate_in_memory=True` in ModelWrapper
-		, which is the default.  
+
+    Notes:
+        For optimal results, you should use a batch size of one
+        during inference time.
+        Furthermore, to guarantee that each sample uses the same
+        set of weights,
+        you must use `replicate_in_memory=True` in ModelWrapper,
+        which is the default.
     """
 
     def __init__(self, p=0.5):
@@ -63,6 +63,14 @@ class ConsistentDropout2d(_DropoutNd):
 
     Args:
         p (float): probability of an element to be zeroed. Default: 0.5
+
+    Notes:
+        For optimal results, you should use a batch size of one
+        during inference time.
+        Furthermore, to guarantee that each sample uses the same
+        set of weights,
+        you must use `replicate_in_memory=True` in ModelWrapper,
+        which is the default.
     """
 
     def __init__(self, p=0.5):

--- a/src/baal/bayesian/consistent_dropout.py
+++ b/src/baal/bayesian/consistent_dropout.py
@@ -1,0 +1,126 @@
+import copy
+
+import torch
+from torch.nn import functional as F
+from torch.nn.modules.dropout import _DropoutNd
+
+
+class ConsistentDropout(_DropoutNd):
+    """
+    ConsistentDropout is useful when doing research.
+    It guarantees that while the mask are the same between batches,
+    they are different inside the batch.
+
+    This is slower than using regular Dropout, but it is useful
+    when you want to use the same set of weights for each unlabelled sample.
+    """
+
+    def __init__(self, p=0.5):
+        super().__init__(p=p, inplace=False)
+        self.reset()
+
+    def forward(self, x):
+        if self.training:
+            return F.dropout(x, self.p, training=True, inplace=False)
+        else:
+            if self._mask is None or self._mask.shape != x.shape:
+                self._mask = self._make_mask(x)
+            return torch.mul(x, self._mask)
+
+    def _make_mask(self, x):
+        return F.dropout(torch.ones_like(x, device=x.device), self.p, training=True)
+
+    def reset(self):
+        self._mask = None
+
+    def eval(self):
+        self.reset()
+        return super().eval()
+
+
+class ConsistentDropout2d(_DropoutNd):
+    """
+    ConsistentDropout is useful when doing research.
+    It guarantees that while the mask are the same between batches,
+    they are different inside the batch.
+
+    This is slower than using regular Dropout, but it is useful
+    when you want to use the same set of weights for each unlabelled sample.
+        """
+
+    def __init__(self, p=0.5):
+        super().__init__(p=p, inplace=False)
+        self.reset()
+
+    def forward(self, x):
+        if self.training:
+            return F.dropout2d(x, self.p, training=True, inplace=False)
+        else:
+            if self._mask is None or self._mask.shape != x.shape:
+                self._mask = self._make_mask(x)
+            return torch.mul(x, self._mask)
+
+    def _make_mask(self, x):
+        return F.dropout2d(torch.ones_like(x, device=x.device), self.p, training=True)
+
+    def reset(self):
+        self._mask = None
+
+    def eval(self):
+        self.reset()
+        return super().eval()
+
+
+def patch_module(module: torch.nn.Module, inplace: bool = True) -> torch.nn.Module:
+    """Replace dropout layers in a model with Consistent Dropout layers.
+
+    Args:
+        module (torch.nn.Module):
+            The module in which you would like to replace dropout layers.
+        inplace (bool, optional):
+            Whether to modify the module in place or return a copy of the module.
+
+    Returns:
+        torch.nn.Module
+            The modified module, which is either the same object as you passed in
+            (if inplace = True) or a copy of that object.
+    """
+    if not inplace:
+        module = copy.deepcopy(module)
+    _patch_dropout_layers(module)
+    return module
+
+
+def _patch_dropout_layers(module: torch.nn.Module) -> None:
+    """
+    Recursively iterate over the children of a module and replace them if
+    they are a dropout layer. This function operates in-place.
+    """
+
+    for name, child in module.named_children():
+        if isinstance(child, torch.nn.Dropout):
+            new_module = ConsistentDropout(p=child.p)
+        elif isinstance(child, torch.nn.Dropout2d):
+            new_module = ConsistentDropout2d(p=child.p)
+        else:
+            new_module = None
+
+        if new_module is not None:
+            module.add_module(name, new_module)
+
+        # recursively apply to child
+        _patch_dropout_layers(child)
+
+
+class MCConsistentDropoutModule(torch.nn.Module):
+    def __init__(self, module: torch.nn.Module):
+        """Create a module that with all dropout layers patched.
+
+        Args:
+            module (torch.nn.Module):
+                A fully specified neural network.
+        """
+        super().__init__()
+        self.parent_module = module
+        _patch_dropout_layers(self.parent_module)
+        self.forward = self.parent_module.forward

--- a/src/baal/bayesian/consistent_dropout.py
+++ b/src/baal/bayesian/consistent_dropout.py
@@ -16,6 +16,14 @@ class ConsistentDropout(_DropoutNd):
 
     Args:
         p (float): probability of an element to be zeroed. Default: 0.5
+	
+	Notes:
+		For optimal results, you should use a batch size of one
+		during inference time.
+		Furthermore, to guarantee that each sample uses the same
+		set of weights,
+		you must use `replicate_in_memory=True` in ModelWrapper
+		, which is the default.  
     """
 
     def __init__(self, p=0.5):

--- a/src/baal/bayesian/consistent_dropout.py
+++ b/src/baal/bayesian/consistent_dropout.py
@@ -8,11 +8,14 @@ from torch.nn.modules.dropout import _DropoutNd
 class ConsistentDropout(_DropoutNd):
     """
     ConsistentDropout is useful when doing research.
-    It guarantees that while the mask are the same between batches,
-    they are different inside the batch.
+    It guarantees that while the masks are the same between batches
+    during inference. The masks are different inside the batch.
 
     This is slower than using regular Dropout, but it is useful
-    when you want to use the same set of weights for each unlabelled sample.
+    when you want to use the same set of weights for each sample used in inference.
+    
+    From BatchBALD (Kirsch et al, 2019), this is necessary to use BatchBALD and remove noise 
+    from the prediction.
 
     Args:
         p (float): probability of an element to be zeroed. Default: 0.5

--- a/src/baal/bayesian/consistent_dropout.py
+++ b/src/baal/bayesian/consistent_dropout.py
@@ -13,6 +13,9 @@ class ConsistentDropout(_DropoutNd):
 
     This is slower than using regular Dropout, but it is useful
     when you want to use the same set of weights for each unlabelled sample.
+
+    Args:
+        p (float): probability of an element to be zeroed. Default: 0.5
     """
 
     def __init__(self, p=0.5):
@@ -46,7 +49,10 @@ class ConsistentDropout2d(_DropoutNd):
 
     This is slower than using regular Dropout, but it is useful
     when you want to use the same set of weights for each unlabelled sample.
-        """
+
+    Args:
+        p (float): probability of an element to be zeroed. Default: 0.5
+    """
 
     def __init__(self, p=0.5):
         super().__init__(p=p, inplace=False)

--- a/tests/bayesian/consistent_dropout_test.py
+++ b/tests/bayesian/consistent_dropout_test.py
@@ -1,0 +1,145 @@
+from copy import deepcopy
+
+import pytest
+import torch
+
+import baal.bayesian.consistent_dropout
+
+
+def test_1d_eval_is_not_stochastic():
+    dummy_input = torch.randn(8, 10)
+    test_module = torch.nn.Sequential(
+        torch.nn.Linear(10, 5),
+        torch.nn.ReLU(),
+        baal.bayesian.consistent_dropout.ConsistentDropout(p=0.5),
+        torch.nn.Linear(5, 2),
+    )
+    test_module.eval()
+    # NOTE: This is quite a stochastic test...
+    torch.manual_seed(2019)
+    with torch.no_grad():
+        assert all(
+            (test_module(dummy_input) == test_module(dummy_input)).all()
+            for _ in range(10)
+        )
+
+
+def test_2d_eval_is_stochastic():
+    dummy_input = torch.randn(8, 1, 5, 5)
+    test_module = torch.nn.Sequential(
+        torch.nn.Conv2d(1, 1, 1),
+        torch.nn.ReLU(),
+        baal.bayesian.consistent_dropout.ConsistentDropout2d(p=0.5),
+        torch.nn.Conv2d(1, 1, 1),
+    )
+    test_module.eval()
+    # NOTE: This is quite a stochastic test...
+    torch.manual_seed(2019)
+    with torch.no_grad():
+        assert all(
+            (test_module(dummy_input) == test_module(dummy_input)).all()
+            for _ in range(10)
+        )
+
+
+@pytest.mark.parametrize("inplace", (True, False))
+def test_patch_module_replaces_all_dropout_layers(inplace):
+    test_module = torch.nn.Sequential(
+        torch.nn.Linear(10, 5),
+        torch.nn.ReLU(),
+        torch.nn.Dropout(p=0.5),
+        torch.nn.Linear(5, 2),
+    )
+
+    mc_test_module = baal.bayesian.consistent_dropout.patch_module(test_module, inplace=inplace)
+
+    # objects should be the same if inplace is True and not otherwise:
+    assert (mc_test_module is test_module) == inplace
+    assert not any(
+        isinstance(module, torch.nn.Dropout) for module in mc_test_module.modules()
+    )
+    assert any(
+        isinstance(module, baal.bayesian.consistent_dropout.ConsistentDropout)
+        for module in mc_test_module.modules()
+    )
+
+
+def test_module_class_replaces_dropout_layers():
+    dummy_input = torch.randn(8, 10)
+    test_module = torch.nn.Sequential(
+        torch.nn.Linear(10, 5),
+        torch.nn.ReLU(),
+        torch.nn.Dropout(p=0.5),
+        torch.nn.Linear(5, 2),
+    )
+    test_mc_module = baal.bayesian.consistent_dropout.MCConsistentDropoutModule(test_module)
+
+    assert not any(
+        isinstance(module, torch.nn.Dropout) for module in test_module.modules()
+    )
+    assert any(
+        isinstance(module, baal.bayesian.consistent_dropout.ConsistentDropout)
+        for module in test_module.modules()
+    )
+    torch.manual_seed(2019)
+    with torch.no_grad():
+        assert not all(
+            torch.eq(test_mc_module(dummy_input), test_mc_module(dummy_input)).all()
+            for _ in range(10)
+        )
+
+    test_mc_module.eval()
+    torch.manual_seed(2019)
+    with torch.no_grad():
+        assert all(
+            torch.eq(test_mc_module(dummy_input), test_mc_module(dummy_input)).all()
+            for _ in range(10)
+        )
+
+
+def test_intra_batch_is_stochastic():
+    dummy_input = torch.randn(10)
+    dummy_input = torch.stack([dummy_input, dummy_input])
+    assert dummy_input.shape == (2, 10)
+    test_module = torch.nn.Sequential(
+        torch.nn.Linear(10, 5),
+        torch.nn.ReLU(),
+        baal.bayesian.consistent_dropout.ConsistentDropout(p=0.5),
+        torch.nn.Linear(5, 2),
+    )
+    test_module.eval()
+    # NOTE: This is quite a stochastic test...
+    torch.manual_seed(2019)
+    pred = test_module(dummy_input)
+    assert (pred[0] - pred[1]).abs().sum() > 0
+
+    assert torch.eq(pred, test_module(dummy_input)).all()
+
+
+def test_masks_changes_1d():
+    i = torch.randn([10, 223])
+    l = baal.bayesian.consistent_dropout.ConsistentDropout()
+    _mask_tests(i, l)
+
+
+def test_masks_changes_2d():
+    i = torch.randn([10, 3, 223, 223])
+    l = baal.bayesian.consistent_dropout.ConsistentDropout2d()
+    _mask_tests(i, l)
+
+
+def _mask_tests(i, l):
+    l.train()
+    l.eval()
+    assert l._mask is None
+    o1 = l(i)
+    mask = deepcopy(l._mask)
+
+    l.train()
+    l.eval()
+    assert l._mask is None
+    o2 = l(i)
+    mask2 = deepcopy(l._mask)
+
+    assert not torch.eq(mask, mask2).all()
+    assert not torch.eq(o1, o2).all()


### PR DESCRIPTION
## Summary:

This (second) PR adds a new component for research user: ConsistentDropout.
While ConsistentDropout is a bit slower, it guarantees the same weights drawn from the posterior distribution for each batch. This is useful when doing research to give every sample the same distribution.

### Features:

It has the same API as baal.bayesian.Dropout so I won't cover it.

The behavior can be seen with this example:

```python
your_model = baal.bayesian.consistent_dropout.patch_module(YourModel())
model = ModelWrapper(your_model)

a_batch = torch.randn(1, 32)  # assuming an input size of 32

out = model.predict_on_batch(a_batch, iterations=10)
assert out.shape[-1] == 10  # We have 10 iterations.

# We compute the uncertainty per batch and it works!
assert (torch.var(out, -1) > 0).all()

# But because we draw the same weights, the preds are the same if we predict again
out2 = model.predict_on_batch(a_batch, iterations=10)
assert torch.eq(out, out2).all()
```

## Checklist:

* [x] Your code is documented (To validate this, add your module to `tests/documentation_test.py`).
* [x] Your code is tested with unit tests.
* [x] You moved your Issue to the PR state.
