### PR TITLE
Fix a bug where BALD would not work on binary classif

### DIFF
--- a/src/baal/active/heuristics/heuristics.py
+++ b/src/baal/active/heuristics/heuristics.py
@@ -179,7 +179,7 @@ class AbstractHeuristic:
         """
         if isinstance(scores, Sequence):
             scores = np.concatenate(scores)
-        assert scores.ndim == 1  # We want the uncertainty value per sample. a
+        assert scores.ndim == 1  # We want the uncertainty value per sample.
         ranks = np.argsort(scores)
         if self.reversed:
             ranks = ranks[::-1]

--- a/src/baal/active/heuristics/heuristics.py
+++ b/src/baal/active/heuristics/heuristics.py
@@ -179,8 +179,8 @@ class AbstractHeuristic:
         """
         if isinstance(scores, Sequence):
             scores = np.concatenate(scores)
-        assert scores.ndim <= 2
-        ranks = np.argsort(scores, -1)
+        assert scores.ndim == 1  # We want the uncertainty value per sample. a
+        ranks = np.argsort(scores)
         if self.reversed:
             ranks = ranks[::-1]
         ranks = _shuffle_subset(ranks, self.shuffle_prop)
@@ -576,7 +576,7 @@ class Random(Precomputed):
 
     def get_ranks(self, predictions):
         if isinstance(predictions, types.GeneratorType):
-            predictions = np.array([1 for _ in predictions])
+            predictions = np.array([np.ones([t.shape[0]]) for t in predictions]).reshape([-1])
         return self.reorder_indices(predictions)
 
 

--- a/src/baal/utils/array_utils.py
+++ b/src/baal/utils/array_utils.py
@@ -1,6 +1,6 @@
 import numpy as np
 import torch
-from scipy.special import softmax
+from scipy.special import softmax, expit
 
 
 def to_prob(probabilities: np.ndarray):
@@ -13,9 +13,14 @@ def to_prob(probabilities: np.ndarray):
     Returns:
         Same as probabilities.
     """
-    bounded = np.min(probabilities) < 0 or np.max(probabilities) > 1.0
-    if bounded or not np.allclose(probabilities.sum(1), 1):
-        probabilities = softmax(probabilities, 1)
+    not_bounded = np.min(probabilities) < 0 or np.max(probabilities) > 1.0
+    multiclass = probabilities.shape[1] > 1
+    sum_to_one = np.allclose(probabilities.sum(1), 1)
+    if not_bounded or (multiclass and not sum_to_one):
+        if multiclass:
+            probabilities = softmax(probabilities, 1)
+        else:
+            probabilities = expit(probabilities)
     return probabilities
 
 

--- a/tests/active/heuristic_test.py
+++ b/tests/active/heuristic_test.py
@@ -1,3 +1,5 @@
+from itertools import cycle
+
 import numpy as np
 import pytest
 from hypothesis import given
@@ -333,6 +335,19 @@ def test_combine_heuristics_reorder_list():
                                    reduction='mean')
     ranks = heuristics.reorder_indices(streaming_prediction)
     assert np.all(ranks == [0, 1, 2]), "Combine Heuristics is not right {}".format(ranks)
+
+@pytest.mark.parametrize("heur", [Random(), BALD(reduction='sum'),
+                                  Entropy(reduction='sum'),
+                                  Variance(reduction='sum')])
+@pytest.mark.parametrize("n_batch", [1, 10, 20])
+def test_heuristics_works_with_generator(heur, n_batch):
+    BATCH_SIZE = 32
+    def predictions(n_batch):
+        for _ in range(n_batch):
+            yield np.random.randn(BATCH_SIZE, 3, 32, 32, 10)
+    preds = predictions(n_batch)
+    out = heur(preds)
+    assert out.shape[0] == n_batch * BATCH_SIZE
 
 
 if __name__ == '__main__':

--- a/tests/utils/test_array_utils.py
+++ b/tests/utils/test_array_utils.py
@@ -1,13 +1,23 @@
 import pytest
 import torch
+from scipy.special import softmax, expit
 
 from baal.utils import array_utils
+from baal.utils.array_utils import to_prob
 from baal.utils.iterutils import map_on_tensor
-
+import numpy as np
 
 @pytest.fixture()
 def a_tensor():
     return torch.randn([10, 3, 32, 32])
+
+@pytest.fixture()
+def an_array():
+    return np.random.randn(10, 3, 32, 32)
+
+@pytest.fixture()
+def a_binary_array():
+    return np.random.randn(10, 1, 32, 32)
 
 
 def test_stack_in_memory_single(a_tensor):
@@ -22,6 +32,25 @@ def test_stack_in_memory_multi(a_tensor):
     out = map_on_tensor(lambda ti: array_utils.stack_in_memory(ti, iterations=iterations), t)
     assert out[0].shape == (10 * iterations, 3, 32, 32)
     assert out[1].shape == (10 * iterations, 3, 32, 32)
+
+def test_to_prob(an_array, a_binary_array):
+    out = to_prob(an_array)
+    assert not np.allclose(out, an_array)
+
+    out = to_prob(a_binary_array)
+    assert not np.allclose(out, a_binary_array)
+
+    a_array_scaled = softmax(an_array, 1)
+    a_binary_array_scaled = expit(a_binary_array)
+
+    out = to_prob(a_array_scaled)
+    assert np.allclose(out, a_array_scaled)
+
+    out = to_prob(a_binary_array_scaled)
+    assert np.allclose(out, a_binary_array_scaled)
+
+
+
 
 
 if __name__ == '__main__':

--- a/tests/utils/test_array_utils.py
+++ b/tests/utils/test_array_utils.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 import torch
 from scipy.special import softmax, expit
@@ -5,15 +6,17 @@ from scipy.special import softmax, expit
 from baal.utils import array_utils
 from baal.utils.array_utils import to_prob
 from baal.utils.iterutils import map_on_tensor
-import numpy as np
+
 
 @pytest.fixture()
 def a_tensor():
     return torch.randn([10, 3, 32, 32])
 
+
 @pytest.fixture()
 def an_array():
     return np.random.randn(10, 3, 32, 32)
+
 
 @pytest.fixture()
 def a_binary_array():
@@ -33,6 +36,7 @@ def test_stack_in_memory_multi(a_tensor):
     assert out[0].shape == (10 * iterations, 3, 32, 32)
     assert out[1].shape == (10 * iterations, 3, 32, 32)
 
+
 def test_to_prob(an_array, a_binary_array):
     out = to_prob(an_array)
     assert not np.allclose(out, an_array)
@@ -48,9 +52,6 @@ def test_to_prob(an_array, a_binary_array):
 
     out = to_prob(a_binary_array_scaled)
     assert np.allclose(out, a_binary_array_scaled)
-
-
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary:
`to_prob` only worked on multiclass classification.
`Random` did not worked on generators.
### Features:
Fixes #59 
Fixes #62 


## Checklist:

* [x] Your code is documented (To validate this, add your module to `tests/documentation_test.py`).
* [x] Your code is tested with unit tests.
* [ ] You moved your Issue to the PR state.
