### PR TITLE
Assert that BatchBALD is only used in classification

### DIFF
--- a/src/baal/active/heuristics/heuristics.py
+++ b/src/baal/active/heuristics/heuristics.py
@@ -344,11 +344,14 @@ class BatchBALD(BALD):
         """
         Compute the joint entropy between `preditions` and `selected`
         Args:
-            predictions (Tensor): First tensor with shape [B, C, ..., Iterations]
+            predictions (Tensor): First tensor with shape [B, C, Iterations]
             selected (Tensor): Second tensor with shape [M, Iterations].
 
         References:
             Code from https://github.com/BlackHC/BatchBALD/blob/master/src/joint_entropy/sampling.py
+
+        Notes:
+            Only Classification is supported, not semantic segmentation or other.
 
         Returns:
             Generator yield B entropies.
@@ -376,7 +379,10 @@ class BatchBALD(BALD):
         Compute the score according to the heuristic.
 
         Args:
-            predictions (ndarray): Array of predictions
+            predictions (ndarray): Array of predictions [batch_size, C, Iterations]
+
+        Notes:
+            Only Classification is supported, not semantic segmentation or other.
 
         Returns:
             Array of scores.
@@ -428,16 +434,23 @@ class BatchBALD(BALD):
         Rank the predictions according to their uncertainties.
 
         Args:
-            predictions (ndarray): [batch_size, C, ..., Iterations]
+            predictions (ndarray): [batch_size, C, Iterations]
 
         Returns:
             Ranked index according to the uncertainty (highest to lowest).
+
+        Notes:
+            Only Classification is supported, not semantic segmentation or other.
 
         Raises:
             ValueError if predictions is a generator.
         """
         if isinstance(predictions, types.GeneratorType):
             raise ValueError("BatchBALD doesn't support generators.")
+
+        if predictions.ndim != 3:
+            raise ValueError("BatchBALD only works on classification"
+                             "Expected shape= [batch_size, C, Iterations]")
 
         ranks = self.get_uncertainties(predictions)
 

--- a/tests/active/heuristic_test.py
+++ b/tests/active/heuristic_test.py
@@ -125,6 +125,16 @@ def test_batch_bald(distributions, reduction):
     # Unlikely, but not 100% sure
     assert np.any(marg != [1, 2, 0])
 
+@pytest.mark.parametrize('distributions, reduction',
+                         [(distributions_5d, 'none')])
+def test_batch_bald_fails_on_5d(distributions, reduction):
+    np.random.seed(1338)
+
+    bald = BatchBALD(100, reduction=reduction)
+    with pytest.raises(ValueError) as e:
+        marg = bald(distributions)
+    assert 'BatchBALD only works on classification' in str(e)
+
 
 @pytest.mark.parametrize('distributions, reduction',
                          [(distributions_5d, 'mean'),


### PR DESCRIPTION
## Summary:

I tried to make BatchBALD work on semantic segmentation but to no avail. 
One of the issues besides the huge memory requirements are on how we sample from the past values. We would need to store the uncertainty per pixel, but we don't have experiments to validate that this is the right way to go.

For now, I updated the documentation and added an assert.

### Features:
Fixes #63 

## Checklist:

* [x] Your code is documented (To validate this, add your module to `tests/documentation_test.py`).
* [x] Your code is tested with unit tests.
* [ ] You moved your Issue to the PR state.
