### PR TITLE
Put model on GPU before predicting and back to CPU after.

### DIFF
--- a/experiments/pl_baal_example.py
+++ b/experiments/pl_baal_example.py
@@ -156,9 +156,9 @@ def main(hparams):
     active_set.label_randomly(10)
     heuristic = BALD()
     model = VGG16(active_set, hparams)
+    dp = 'dp' if hparams.n_gpus > 1 else None
     trainer = BaalTrainer(max_epochs=3, default_root_dir=hparams.data_root,
-                          gpus=hparams.n_gpus, distributed_backend='dp'
-        if hparams.n_gpus > 1 else None,
+                          gpus=hparams.n_gpus, distributed_backend=dp,
                           # The weights of the model will change as it gets
                           # trained; we need to keep a copy (deepcopy) so that
                           # we can reset them.
@@ -169,7 +169,7 @@ def main(hparams):
 
     AL_STEPS = 100
     for al_step in range(AL_STEPS):
-        print(f'Step {al_step} DS size {len(active_set)}')
+        print(f'Step {al_step} Dataset size {len(active_set)}')
         trainer.fit(model)
         should_continue = loop.step()
         if not should_continue:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ torchvision>=0.2.2
 tqdm
 h5py
 structlog
+pydantic
 pytorch-lightning==0.8.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,4 @@ torchvision>=0.2.2
 tqdm
 h5py
 structlog
-pydantic
 pytorch-lightning==0.8.5

--- a/src/baal/utils/pytorch_lightning.py
+++ b/src/baal/utils/pytorch_lightning.py
@@ -56,6 +56,8 @@ class BaalTrainer(Trainer):
     def predict_on_dataset_generator(self, *args, **kwargs):
         model = self.get_model()
         model.eval()
+        if self.on_gpu:
+            model.cuda(self.root_gpu)
         dataloader = self.model.pool_loader()
         if len(dataloader) == 0:
             return None
@@ -66,3 +68,5 @@ class BaalTrainer(Trainer):
                 data = to_cuda(data)
             pred = self.model.predict_step(data, idx)
             yield map_on_tensor(lambda x: x.detach().cpu().numpy(), pred)
+        # teardown, TODO customize this later?
+        model.cpu()


### PR DESCRIPTION
## Summary:

PL puts the model back on CPU after training. We now mimic the same behaviour.

### Features:

Fixes #79 

## Checklist:

* [x] Your code is documented (To validate this, add your module to `tests/documentation_test.py`).
* [x] Your code is tested with unit tests.
* [ ] You moved your Issue to the PR state.
