### PR TITLE
#60 Better error handling when reduction is not set

### DIFF
--- a/src/baal/active/heuristics/heuristics.py
+++ b/src/baal/active/heuristics/heuristics.py
@@ -111,6 +111,7 @@ class AbstractHeuristic:
         self.shuffle_prop = shuffle_prop
         self.reversed = reverse
         assert reduction in available_reductions or callable(reduction)
+        self._reduction_name = reduction
         self.reduction = reduction if callable(reduction) else available_reductions[reduction]
 
     def compute_score(self, predictions):
@@ -179,6 +180,11 @@ class AbstractHeuristic:
         """
         if isinstance(scores, Sequence):
             scores = np.concatenate(scores)
+
+        if scores.ndim > 1:
+            raise ValueError((f"Can't order sequence with more than 1 dimension."
+                              f"Currently {scores.ndim} dimensions."
+                              f"Is the heuristic reduction method set: {self._reduction_name}"))
         assert scores.ndim == 1  # We want the uncertainty value per sample.
         ranks = np.argsort(scores)
         if self.reversed:

--- a/src/baal/active/heuristics/heuristics.py
+++ b/src/baal/active/heuristics/heuristics.py
@@ -177,6 +177,9 @@ class AbstractHeuristic:
 
         Returns:
             ordered index according to the uncertainty (highest to lowes).
+
+        Raises:
+            ValueError if `scores` is not uni-dimensional.
         """
         if isinstance(scores, Sequence):
             scores = np.concatenate(scores)

--- a/tests/active/heuristic_test.py
+++ b/tests/active/heuristic_test.py
@@ -1,5 +1,3 @@
-from itertools import cycle
-
 import numpy as np
 import pytest
 from hypothesis import given
@@ -124,6 +122,7 @@ def test_batch_bald(distributions, reduction):
 
     # Unlikely, but not 100% sure
     assert np.any(marg != [1, 2, 0])
+
 
 @pytest.mark.parametrize('distributions, reduction',
                          [(distributions_5d, 'none')])
@@ -346,18 +345,30 @@ def test_combine_heuristics_reorder_list():
     ranks = heuristics.reorder_indices(streaming_prediction)
     assert np.all(ranks == [0, 1, 2]), "Combine Heuristics is not right {}".format(ranks)
 
+
 @pytest.mark.parametrize("heur", [Random(), BALD(reduction='sum'),
                                   Entropy(reduction='sum'),
                                   Variance(reduction='sum')])
 @pytest.mark.parametrize("n_batch", [1, 10, 20])
 def test_heuristics_works_with_generator(heur, n_batch):
     BATCH_SIZE = 32
+
     def predictions(n_batch):
         for _ in range(n_batch):
             yield np.random.randn(BATCH_SIZE, 3, 32, 32, 10)
+
     preds = predictions(n_batch)
     out = heur(preds)
     assert out.shape[0] == n_batch * BATCH_SIZE
+
+
+@pytest.mark.parametrize('distributions', [distributions_5d])
+def test_heuristic_reductio_check(distributions):
+    np.random.seed(1337)
+    heuristic = BALD(reduction='none')
+    with pytest.raises(ValueError) as e_info:
+        heuristic(distributions)
+        assert "Can't order sequence with more than 1 dimension." in str(e_info.value)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary:

When reduction is not set properly, the number of dimensions is bigger than 1 and we don't support that. Previously the error was cryptic. Now it is a bit better.

### Features:
Fixes #60 


## Checklist:

* [x] Your code is documented (To validate this, add your module to `tests/documentation_test.py`).
* [x] Your code is tested with unit tests.
* [x] You moved your Issue to the PR state.
