### PR TITLE
Fixing the copying method for the init_weights

### DIFF
--- a/experiments/nlp_bert_mcdropout.py
+++ b/experiments/nlp_bert_mcdropout.py
@@ -127,7 +127,7 @@ def main():
             should_continue = active_loop.step()
 
             # We reset the model weights to relearn from the new trainset.
-            model.load_state_dict(init_weights)
+            model.model.load_state_dict(init_weights)
             if not should_continue:
                 break
         active_logs = {"epoch": epoch,


### PR DESCRIPTION
model.load_state_dict(init_weights) on its second iteration will make it constant leading to no change in its weights due to training. On changing it to model.model.load_state_dict(init_weights), we are directly assigning the model with its initial weights. More on https://huggingface.co/transformers/main_classes/trainer.html

## Summary:
Simple fix
### Features:


## Checklist:

* [ ] Your code is documented (To validate this, add your module to `tests/documentation_test.py`).
* [ ] Your code is tested with unit tests.
* [ ] You moved your Issue to the PR state.
