### PR TITLE
Add check for pytorch 1.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ structlog
 pytorch-lightning==0.8.5
 transformers
 datasets
+packaging


### PR DESCRIPTION
## Summary:

In Pytorch>=1.8, they modified the internal API and added `bias` to the signature.
