### PR TITLE
Torchvision dep to test requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ Pillow>=6.2.0
 scikit-learn
 scipy
 torch>=1.6.0
-torchvision>=0.7.0
 tqdm
 h5py
 structlog

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
     ],
     install_requires=reqs,
     extras_require={
-        'test': ['pytest', 'pytest-pep8', 'hypothesis', 'coverage', 'coveralls'],
+        'test': ['pytest', 'pytest-pep8', 'hypothesis', 'coverage', 'coveralls', 'torchvision>=0.7.0'],
         'nlp': ['transformers', 'datasets'],
         'documentation': documentation_requirements,
     },

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,9 @@ def read(*names, **kwargs):
 with open('requirements.txt') as f:
     reqs = [line.strip() for line in f]
 
+with open('test-requirements.txt') as f:
+    testreqs = [line.strip() for line in f]
+
 with open('documentation-requirements.txt') as f:
     documentation_requirements = [line.strip() for line in f]
 
@@ -62,7 +65,7 @@ setup(
     ],
     install_requires=reqs,
     extras_require={
-        'test': ['pytest', 'pytest-pep8', 'hypothesis', 'coverage', 'coveralls', 'torchvision>=0.7.0'],
+        'test': testreqs,
         'nlp': ['transformers', 'datasets'],
         'documentation': documentation_requirements,
     },

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,9 @@ with open('test-requirements.txt') as f:
 with open('documentation-requirements.txt') as f:
     documentation_requirements = [line.strip() for line in f]
 
+# vision dependencies are also used for testing
+visionreqs = ['torchvision>=0.7.0']
+
 setup(
     name='baal',
     version=version['__version__'],
@@ -65,8 +68,9 @@ setup(
     ],
     install_requires=reqs,
     extras_require={
-        'test': testreqs,
+        'test': testreqs + visionreqs,
         'nlp': ['transformers', 'datasets'],
+        'vision': visionreqs,
         'documentation': documentation_requirements,
     },
 )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,7 +3,6 @@ pytest-pep8
 pytest-cov
 coverage
 torch-hypothesis==0.2.0
-torchvision>=0.7.0
 hypothesis==4.24.0
 pytest-mock
 flake8

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,6 +3,7 @@ pytest-pep8
 pytest-cov
 coverage
 torch-hypothesis==0.2.0
+torchvision>=0.7.0
 hypothesis==4.24.0
 pytest-mock
 flake8


### PR DESCRIPTION
## Summary:
  This is to reduce dependencies for projects that use baal for non-vision applications.

```
% pip install -e .\[test\]
[...]
  Running setup.py develop for baal
Successfully installed baal-1.3.0 [...] torchvision-0.10.0
```