### PR TITLE
Give ability for users to get uncertainty values.

### DIFF
--- a/experiments/nlp_bert_mcdropout.py
+++ b/experiments/nlp_bert_mcdropout.py
@@ -15,7 +15,8 @@ from datasets import load_dataset
 from transformers import BertTokenizer, TrainingArguments
 from transformers import BertForSequenceClassification
 
-from baal.active import get_heuristic, active_huggingface_dataset, HuggingFaceDatasets
+from baal.active import get_heuristic
+from baal.active.nlp_datasets import active_huggingface_dataset, HuggingFaceDatasets
 from baal.active.active_loop import ActiveLearningLoop
 from baal.bayesian.dropout import patch_module
 from baal.transformers_trainer_wrapper import BaalTransformersTrainer

--- a/src/baal/active/__init__.py
+++ b/src/baal/active/__init__.py
@@ -1,10 +1,9 @@
-from typing import Union, Callable, Dict
+from typing import Union, Callable
 
 from . import heuristics
 from .active_loop import ActiveLearningLoop
 from .dataset import ActiveLearningDataset
 from .file_dataset import FileDataset
-from .nlp_datasets import HuggingFaceDatasets
 
 
 def get_heuristic(name: str, shuffle_prop: float = 0.0,
@@ -34,29 +33,3 @@ def get_heuristic(name: str, shuffle_prop: float = 0.0,
     }[name](shuffle_prop=shuffle_prop, reduction=reduction, **kwargs)
 
 
-def active_huggingface_dataset(dataset,
-                               tokenizer=None,
-                               target_key: str = "label",
-                               input_key: str = "sentence",
-                               max_seq_len: int = 128,
-                               **kwargs):
-    """
-    Wrapping huggingface.datasets with baal.active.ActiveLearningDataset.
-
-    Args:
-        dataset (torch.utils.data.Dataset): a dataset provided by huggingface.
-        tokenizer (transformers.PreTrainedTokenizer): a tokenizer provided by huggingface.
-        target_key (str): target key used in the dataset's dictionary.
-        input_key (str): input key used in the dataset's dictionary.
-        max_seq_len (int): max length of a sequence to be used for padding the shorter sequences.
-        kwargs (Dict): Parameters forwarded to 'ActiveLearningDataset'.
-
-    Returns:
-        an baal.active.ActiveLearningDataset object.
-    """
-
-    return ActiveLearningDataset(HuggingFaceDatasets(dataset,
-                                                     tokenizer,
-                                                     target_key,
-                                                     input_key,
-                                                     max_seq_len), **kwargs)

--- a/src/baal/active/__init__.py
+++ b/src/baal/active/__init__.py
@@ -31,5 +31,3 @@ def get_heuristic(name: str, shuffle_prop: float = 0.0,
         'precomputed': heuristics.Precomputed,
         'batch_bald': heuristics.BatchBALD
     }[name](shuffle_prop=shuffle_prop, reduction=reduction, **kwargs)
-
-

--- a/src/baal/active/active_loop.py
+++ b/src/baal/active/active_loop.py
@@ -75,12 +75,14 @@ class ActiveLearningLoop:
                     to_label = indices[np.array(to_label)]
                 if self.uncertainty_folder is not None:
                     # We save uncertainty in a file.
+                    uncertainty_name = f"uncertainty_pool={len(pool)}" \
+                                       f"_labelled={len(self.dataset)}.pkl"
                     pickle.dump({
                         'indices': indices,
                         'uncertainty': uncertainty,
                         'dataset': self.dataset.state_dict()},
                         open(pjoin(self.uncertainty_folder,
-                                   f"uncertainty_pool={len(pool)}_labelled={len(self.dataset)}.pkl"),
+                                   uncertainty_name),
                              'wb'))
                 if len(to_label) > 0:
                     self.dataset.label(to_label[: self.ndata_to_label])

--- a/src/baal/active/active_loop.py
+++ b/src/baal/active/active_loop.py
@@ -1,3 +1,5 @@
+import os
+import pickle
 import types
 from typing import Callable
 
@@ -6,6 +8,8 @@ import torch.utils.data as torchdata
 
 from . import heuristics
 from .dataset import ActiveLearningDataset
+
+pjoin = os.path.join
 
 
 class ActiveLearningLoop:
@@ -18,23 +22,26 @@ class ActiveLearningLoop:
         heuristic (Heuristic): Heuristic from baal.active.heuristics.
         ndata_to_label (int): Number of sample to label per step.
         max_sample (int): Limit the number of sample used (-1 is no limit).
+        uncertainty_folder (Optional[str]): If provided, will store uncertainties on disk.
         **kwargs: Parameters forwarded to `get_probabilities`.
     """
 
     def __init__(
-        self,
-        dataset: ActiveLearningDataset,
-        get_probabilities: Callable,
-        heuristic: heuristics.AbstractHeuristic = heuristics.Random(),
-        ndata_to_label: int = 1,
-        max_sample=-1,
-        **kwargs,
+            self,
+            dataset: ActiveLearningDataset,
+            get_probabilities: Callable,
+            heuristic: heuristics.AbstractHeuristic = heuristics.Random(),
+            ndata_to_label: int = 1,
+            max_sample=-1,
+            uncertainty_folder=None,
+            **kwargs,
     ) -> None:
         self.ndata_to_label = ndata_to_label
         self.get_probabilities = get_probabilities
         self.heuristic = heuristic
         self.dataset = dataset
         self.max_sample = max_sample
+        self.uncertainty_folder = uncertainty_folder
         self.kwargs = kwargs
 
     def step(self, pool=None) -> bool:
@@ -48,7 +55,6 @@ class ActiveLearningLoop:
             boolean, Flag indicating if we continue training.
 
         """
-        # High to low
         if pool is None:
             pool = self.dataset.pool
             if len(pool) > 0:
@@ -64,9 +70,18 @@ class ActiveLearningLoop:
         if len(pool) > 0:
             probs = self.get_probabilities(pool, **self.kwargs)
             if probs is not None and (isinstance(probs, types.GeneratorType) or len(probs) > 0):
-                to_label = self.heuristic(probs)
+                to_label, uncertainty = self.heuristic.get_ranks(probs)
                 if indices is not None:
                     to_label = indices[np.array(to_label)]
+                if self.uncertainty_folder is not None:
+                    # We save uncertainty in a file.
+                    pickle.dump({
+                        'indices': indices,
+                        'uncertainty': uncertainty,
+                        'dataset': self.dataset.state_dict()},
+                        open(pjoin(self.uncertainty_folder,
+                                   f"uncertainty_pool={len(pool)}_labelled={len(self.dataset)}.pkl"),
+                             'wb'))
                 if len(to_label) > 0:
                     self.dataset.label(to_label[: self.ndata_to_label])
                     return True

--- a/src/baal/active/heuristics/heuristics.py
+++ b/src/baal/active/heuristics/heuristics.py
@@ -234,6 +234,7 @@ class AbstractHeuristic:
 
         Returns:
             Ranked index according to the uncertainty (highest to lowes).
+            Scores for all predictions.
 
         """
         if isinstance(predictions, types.GeneratorType):
@@ -604,6 +605,7 @@ class Random(Precomputed):
     Args:
         shuffle_prop (float): UNUSED
         reduction (Union[str, callable]): UNUSED.
+        seed (Optional[int]): If provided, will seed the random generator.
     """
 
     def __init__(self, shuffle_prop=0.0, reduction='none', seed=None):

--- a/src/baal/active/nlp_datasets.py
+++ b/src/baal/active/nlp_datasets.py
@@ -1,5 +1,6 @@
 import numpy as np
 import torch
+from baal.active import ActiveLearningDataset
 from torch.utils.data import Dataset
 from datasets import Dataset as HFDataset
 
@@ -61,3 +62,31 @@ class HuggingFaceDatasets(Dataset):
                 'attention_mask':
                     self.attention_masks[idx].flatten() if len(self.attention_masks) > 0 else None,
                 'label': torch.tensor(target, dtype=torch.long)}
+
+
+def active_huggingface_dataset(dataset,
+                               tokenizer=None,
+                               target_key: str = "label",
+                               input_key: str = "sentence",
+                               max_seq_len: int = 128,
+                               **kwargs):
+    """
+    Wrapping huggingface.datasets with baal.active.ActiveLearningDataset.
+
+    Args:
+        dataset (torch.utils.data.Dataset): a dataset provided by huggingface.
+        tokenizer (transformers.PreTrainedTokenizer): a tokenizer provided by huggingface.
+        target_key (str): target key used in the dataset's dictionary.
+        input_key (str): input key used in the dataset's dictionary.
+        max_seq_len (int): max length of a sequence to be used for padding the shorter sequences.
+        kwargs (Dict): Parameters forwarded to 'ActiveLearningDataset'.
+
+    Returns:
+        an baal.active.ActiveLearningDataset object.
+    """
+
+    return ActiveLearningDataset(HuggingFaceDatasets(dataset,
+                                                     tokenizer,
+                                                     target_key,
+                                                     input_key,
+                                                     max_seq_len), **kwargs)

--- a/src/baal/active/nlp_datasets.py
+++ b/src/baal/active/nlp_datasets.py
@@ -1,8 +1,9 @@
 import numpy as np
 import torch
-from baal.active import ActiveLearningDataset
-from torch.utils.data import Dataset
 from datasets import Dataset as HFDataset
+from torch.utils.data import Dataset
+
+from baal.active import ActiveLearningDataset
 
 
 class HuggingFaceDatasets(Dataset):

--- a/tests/active/active_loop_test.py
+++ b/tests/active/active_loop_test.py
@@ -1,9 +1,14 @@
+import os
+import pickle
+
 import numpy as np
 import pytest
 from torch.utils.data import Dataset
 
 from baal.active import ActiveLearningDataset, heuristics
 from baal.active.active_loop import ActiveLearningLoop
+
+pjoin = os.path.join
 
 
 class MyDataset(Dataset):
@@ -97,6 +102,28 @@ def test_sad(max_sample, expected):
     dataset.label_randomly(10)
     active_loop.step()
     assert len(dataset) == 10 + expected
+
+
+def test_file_saving(tmpdir):
+    tmpdir = str(tmpdir)
+    heur = heuristics.BALD()
+    ds = MyDataset()
+    dataset = ActiveLearningDataset(ds, make_unlabelled=lambda x: -1)
+    active_loop = ActiveLearningLoop(dataset,
+                                     get_probs_iter,
+                                     heur,
+                                     uncertainty_folder=tmpdir,
+                                     ndata_to_label=10,
+                                     dummy_param=1)
+    dataset.label_randomly(10)
+    _ = active_loop.step()
+    assert len(os.listdir(tmpdir)) == 1
+    file = pjoin(tmpdir, os.listdir(tmpdir)[0])
+    assert "pool=90" in file and "labelled=10"
+    data = pickle.load(open(file, 'rb'))
+    assert len(data['uncertainty']) == 90
+    # The diff between the current state and the step before is the newly labelled item.
+    assert (data['dataset']['labelled'] != dataset.labelled).sum() == 10
 
 
 if __name__ == '__main__':

--- a/tests/active/active_loop_test.py
+++ b/tests/active/active_loop_test.py
@@ -119,7 +119,7 @@ def test_file_saving(tmpdir):
     _ = active_loop.step()
     assert len(os.listdir(tmpdir)) == 1
     file = pjoin(tmpdir, os.listdir(tmpdir)[0])
-    assert "pool=90" in file and "labelled=10"
+    assert "pool=90" in file and "labelled=10" in file
     data = pickle.load(open(file, 'rb'))
     assert len(data['uncertainty']) == 90
     # The diff between the current state and the step before is the newly labelled item.

--- a/tests/active/heuristic_test.py
+++ b/tests/active/heuristic_test.py
@@ -115,13 +115,13 @@ def test_batch_bald(distributions, reduction):
     bald = BatchBALD(100, reduction=reduction)
     marg = bald(distributions)
 
-    assert np.all(marg[:3] == [1, 2, 0]), "BatchBALD is not right {}".format(marg)
+    assert np.all(marg[:3] == [2, 1, 0]), "BatchBALD is not right {}".format(marg)
 
     bald = BatchBALD(100, shuffle_prop=0.99, reduction=reduction)
     marg = bald(distributions)
 
     # Unlikely, but not 100% sure
-    assert np.any(marg != [1, 2, 0])
+    assert np.any(marg != [2, 1, 0])
 
 
 @pytest.mark.parametrize('distributions, reduction',


### PR DESCRIPTION
## Summary:

Allow the user to store uncertainties on disk when calling `ActiveLearningLoop.step`.

An issue that this create is that BatchBALD indices are not correlated with their uncertainty so this breaks a test. Not sure what is the best course of action.

### Features:

Fix issue where NLPDataset was always imported.

## Checklist:

* [x] Your code is documented (To validate this, add your module to `tests/documentation_test.py`).
* [x] Your code is tested with unit tests.
* [ ] You moved your Issue to the PR state.
