### PR TITLE
added missing label method for nlp_datasets

### DIFF
--- a/baal/active/nlp_datasets.py
+++ b/baal/active/nlp_datasets.py
@@ -54,6 +54,10 @@ class HuggingFaceDatasets(Dataset):
         )
         return tokenized["input_ids"], tokenized["attention_mask"]
 
+    def label(self,idx,value):
+        #print(self.targets,idx)
+        self.targets[idx] = value
+
     def __len__(self):
         return len(self.texts)
 


### PR DESCRIPTION
## Summary:
`nlp_datasets.py` was missing the `label` method. This caused a breakage of the huggingface wrapper when labelling the active dataset. It couldn't validate the dataset as able to be labelled, and thereby went into the backup condition and suffered a keyerror when looking for key '0'.
### Features:
Added a `label` method for `nlp_datasets` which sets the value for the index of the targets array.

## Checklist:

* [ ] Your code is documented (To validate this, add your module to `tests/documentation_test.py`).
* [ ] Your code is tested with unit tests.
* [ ] You moved your Issue to the PR state.
