### PR TITLE
#192 Use configure instead of configure_once to remove warnings

### DIFF
--- a/baal/utils/log_configuration.py
+++ b/baal/utils/log_configuration.py
@@ -15,7 +15,7 @@ from structlog.stdlib import add_log_level
 
 
 def set_logger_config():
-    structlog.configure_once(
+    structlog.configure(
         processors=[
             structlog.stdlib.PositionalArgumentsFormatter(),
             StackInfoRenderer(),


### PR DESCRIPTION
## Summary:

### Features:

Fixes #192 


## Checklist:

* [ ] Your code is documented (To validate this, add your module to `tests/documentation_test.py`).
* [ ] Your code is tested with unit tests.
* [ ] You moved your Issue to the PR state.
